### PR TITLE
don't use alias for pm4ml-mojaloop-connector

### DIFF
--- a/mojaloop-payment-manager/values.yaml
+++ b/mojaloop-payment-manager/values.yaml
@@ -123,7 +123,7 @@ redis:
     persistence:
       enabled: true
 
-mojaloop-connector:
+pm4ml-mojaloop-connector:
   imagePullCredentials: *imagePullCredentials
   env:
     DFSP_ID: *dfspId


### PR DESCRIPTION
mojaloop-connector alias for pm4ml-mojaloop-connector doesn't seem to work when values files are merged.  removing the alias use in master values file