### PR TITLE
bump version of mojaloop-connector image

### DIFF
--- a/mojaloop-payment-manager/Chart.yaml
+++ b/mojaloop-payment-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 3.1.4
-appVersion: "v3.1.4"
+version: 3.1.5
+appVersion: "v3.1.5"
 description: Helm chart for Mojaloop Payment Manager
 name: mojaloop-payment-manager
 maintainers:

--- a/mojaloop-payment-manager/requirements.yaml
+++ b/mojaloop-payment-manager/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled
 - name: pm4ml-mojaloop-connector
-  version: 1.2.4
+  version: 1.2.5
   repository: file://../pm4ml-mojaloop-connector
   condition: pm4ml-mojaloop-connector.enabled
 - name: mojaloop-core-connector

--- a/pm4ml-mojaloop-connector/Chart.yaml
+++ b/pm4ml-mojaloop-connector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "12.4.1"
+appVersion: "13.7.3"
 description: A Helm chart for Kubernetes
 name: pm4ml-mojaloop-connector
-version: 1.2.4
+version: 1.2.5

--- a/pm4ml-mojaloop-connector/values.yaml
+++ b/pm4ml-mojaloop-connector/values.yaml
@@ -54,7 +54,7 @@ secrets:
 
 image:
   repository: pm4ml/mojaloop-connector
-  tag: 13.7.0
+  tag: 13.7.3
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Update to latest version of mojaloop-connector image to pull bugfix for outbound GET /parties authentication.