### PR TITLE
Release/v4.2.13

### DIFF
--- a/mojaloop-payment-manager/Chart.yaml
+++ b/mojaloop-payment-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 4.2.12
-appVersion: "v4.2.12"
+version: 4.2.13
+appVersion: "v4.2.13"
 description: Helm chart for Mojaloop Payment Manager
 name: mojaloop-payment-manager
 maintainers:
@@ -30,7 +30,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled
 - name: pm4ml-mojaloop-connector
-  version: 1.3.12
+  version: 1.3.13
   repository: file://../pm4ml-mojaloop-connector
   condition: pm4ml-mojaloop-connector.enabled
 - name: mojaloop-core-connector
@@ -57,6 +57,6 @@ dependencies:
   alias: keycloak
   condition: keycloak.enabled
 - name: sim-backend
-  version: 1.0.2
+  version: 1.0.3
   repository: file://../mojaloop-simulator-backend
   condition: sim-backend.enabled

--- a/mojaloop-simulator-backend/Chart.yaml
+++ b/mojaloop-simulator-backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: "Helm Chart for the Mojaloop Simulator Backend"
 name: sim-backend
-version: 1.0.2
-appVersion: "mojaloop-simulator: v11.4.1"
+version: 1.0.3
+appVersion: "mojaloop-simulator: v12.1.0"

--- a/mojaloop-simulator-backend/values.yaml
+++ b/mojaloop-simulator-backend/values.yaml
@@ -57,7 +57,7 @@ env:
 
 image:
   repository: mojaloop/mojaloop-simulator
-  tag: v11.4.1
+  tag: v12.1.0
 
 ingress:
   enabled:

--- a/pm4ml-mojaloop-connector/Chart.yaml
+++ b/pm4ml-mojaloop-connector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "14.1.11"
+appVersion: "14.1.12"
 description: A Helm chart for Kubernetes
 name: pm4ml-mojaloop-connector
-version: 1.3.12
+version: 1.3.13

--- a/pm4ml-mojaloop-connector/values.yaml
+++ b/pm4ml-mojaloop-connector/values.yaml
@@ -28,7 +28,7 @@ env:
 
 image:
   repository: pm4ml/mojaloop-connector
-  tag: 14.1.11
+  tag: 14.1.12
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Updates to mojaloop-connector and sim-backend for mbp-286 which adds to the POST /transfers Swagger definition 3 new fields on its response; fulfilment, transferState or completedTimestamp to enable automation of negative scenarios. The negative scenario of interest and the one enabled by the POST /transfers rule added to https://github.com/mojaloop/mojaloop-simulator/releases/tag/v12.1.0 is in the case an invalid fulfilment is returned by the backend so it can be relayed by the core-connector to the mojaloop-connector to the Mojaloop Hub so upon fulfilment validation fails and triggers a PATCH transferState=ABORTED notification.