### PR TITLE
Release/v4.2.14

### DIFF
--- a/mojaloop-payment-manager/Chart.yaml
+++ b/mojaloop-payment-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 4.2.13
-appVersion: "v4.2.13"
+version: 4.2.14
+appVersion: "v4.2.14"
 description: Helm chart for Mojaloop Payment Manager
 name: mojaloop-payment-manager
 maintainers:
@@ -57,6 +57,6 @@ dependencies:
   alias: keycloak
   condition: keycloak.enabled
 - name: sim-backend
-  version: 1.0.3
+  version: 1.0.4
   repository: file://../mojaloop-simulator-backend
   condition: sim-backend.enabled

--- a/mojaloop-simulator-backend/Chart.yaml
+++ b/mojaloop-simulator-backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: "Helm Chart for the Mojaloop Simulator Backend"
 name: sim-backend
-version: 1.0.3
-appVersion: "mojaloop-simulator: v12.1.0"
+version: 1.0.4
+appVersion: "mojaloop-simulator: v12.1.1"

--- a/mojaloop-simulator-backend/values.yaml
+++ b/mojaloop-simulator-backend/values.yaml
@@ -57,7 +57,7 @@ env:
 
 image:
   repository: mojaloop/mojaloop-simulator
-  tag: v12.1.0
+  tag: v12.1.1
 
 ingress:
   enabled:


### PR DESCRIPTION
Release Notes:
New Feature:
-mbp-286 adds to the POST /transfers Swagger definition 3 new fields on its response; fulfilment, transferState or completedTimestamp to enable automation of negative scenarios. The negative scenario of interest and the one enabled by the POST /transfers rule added to https://github.com/mojaloop/mojaloop-simulator/releases/tag/v12.1.1 is in the case an invalid fulfilment is returned by the backend so it can be relayed by the core-connector to the mojaloop-connector to the Mojaloop Hub so upon fulfilment validation fails and triggers a PATCH transferState=ABORTED notification.